### PR TITLE
add native image support for CLI app with GraalVM

### DIFF
--- a/CLI/build-native.sh
+++ b/CLI/build-native.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-echo "Building native CLI application..."
+echo "Building optimized native CLI application..."
+
+# Set native image environment variables for better performance
+export NATIVE_IMAGE_CONFIG_FILE="src/main/resources/META-INF/native-image"
 
 echo "Step 1: Clean and compile..."
 ./mvnw clean compile
@@ -8,8 +11,10 @@ echo "Step 1: Clean and compile..."
 echo "Step 2: Process AOT..."
 ./mvnw spring-boot:process-aot
 
-echo "Step 3: Build native image..."
-./mvnw -Pnative native:compile
+echo "Step 3: Build optimized native image..."
+# Use more memory for faster builds and enable parallel compilation
+export MAVEN_OPTS="-Xmx4g"
+./mvnw -Pnative native:compile -Dgraalvm.version=21.0.1 -Djava.awt.headless=true
 
 if [ -f "target/rag-cli" ]; then
     echo "✅ Native image built successfully!"

--- a/CLI/build-native.sh
+++ b/CLI/build-native.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+echo "Building native CLI application..."
+
+echo "Step 1: Clean and compile..."
+./mvnw clean compile
+
+echo "Step 2: Process AOT..."
+./mvnw spring-boot:process-aot
+
+echo "Step 3: Build native image..."
+./mvnw -Pnative native:compile
+
+if [ -f "target/rag-cli" ]; then
+    echo "✅ Native image built successfully!"
+    echo "📁 Binary location: target/rag-cli"
+    echo "📊 Binary size:"
+    ls -lh target/rag-cli
+    echo ""
+    echo "🚀 To run: ./target/rag-cli"
+else
+    echo "❌ Native image build failed!"
+    exit 1
+fi
+

--- a/CLI/pom.xml
+++ b/CLI/pom.xml
@@ -73,22 +73,6 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.graalvm.buildtools</groupId>
-				<artifactId>native-maven-plugin</artifactId>
-				<version>${native.maven.plugin.version}</version>
-				<configuration>
-					<imageName>rag-cli</imageName>
-					<mainClass>com.AidanC.CLI.CliApplication</mainClass>
-					<buildArgs>
-						<buildArg>--no-fallback</buildArg>
-						<buildArg>--enable-preview</buildArg>
-						<buildArg>-H:+ReportExceptionStackTraces</buildArg>
-						<buildArg>-H:+AddAllCharsets</buildArg>
-						<buildArg>-H:IncludeResources=application.*</buildArg>
-					</buildArgs>
-				</configuration>
-			</plugin>
-			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 				<configuration>
@@ -118,6 +102,20 @@
 					<plugin>
 						<groupId>org.graalvm.buildtools</groupId>
 						<artifactId>native-maven-plugin</artifactId>
+						<version>${native.maven.plugin.version}</version>
+						<configuration>
+							<imageName>rag-cli</imageName>
+							<mainClass>com.AidanC.CLI.CliApplication</mainClass>
+							<buildArgs>
+								<buildArg>--no-fallback</buildArg>
+								<buildArg>--enable-preview</buildArg>
+								<buildArg>-H:+ReportExceptionStackTraces</buildArg>
+								<buildArg>-H:+AddAllCharsets</buildArg>
+								<buildArg>-H:IncludeResources=application.*</buildArg>
+								<buildArg>-O2</buildArg>
+								<buildArg>-H:+UnlockExperimentalVMOptions</buildArg>
+							</buildArgs>
+						</configuration>
 						<executions>
 							<execution>
 								<id>build-native</id>

--- a/CLI/pom.xml
+++ b/CLI/pom.xml
@@ -30,6 +30,8 @@
 	<properties>
 		<java.version>21</java.version>
 		<spring-shell.version>3.2.3</spring-shell.version>
+		<native.maven.plugin.version>0.10.2</native.maven.plugin.version>
+		<spring.aot.enabled>true</spring.aot.enabled>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -73,10 +75,38 @@
 			<plugin>
 				<groupId>org.graalvm.buildtools</groupId>
 				<artifactId>native-maven-plugin</artifactId>
+				<version>${native.maven.plugin.version}</version>
+				<configuration>
+					<imageName>rag-cli</imageName>
+					<mainClass>com.AidanC.CLI.CliApplication</mainClass>
+					<buildArgs>
+						<buildArg>--no-fallback</buildArg>
+						<buildArg>--enable-preview</buildArg>
+						<buildArg>-H:+ReportExceptionStackTraces</buildArg>
+						<buildArg>-H:+AddAllCharsets</buildArg>
+						<buildArg>-H:IncludeResources=application.*</buildArg>
+					</buildArgs>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+				<configuration>
+					<excludes>
+						<exclude>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+						</exclude>
+					</excludes>
+				</configuration>
+				<executions>
+					<execution>
+						<id>process-aot</id>
+						<goals>
+							<goal>process-aot</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/CLI/src/main/java/com/AidanC/CLI/NativeImageConfiguration.java
+++ b/CLI/src/main/java/com/AidanC/CLI/NativeImageConfiguration.java
@@ -14,15 +14,15 @@ public class NativeImageConfiguration {
         @Override
         public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
             hints.reflection()
-                .registerType(ApiCommand.class, MemberCategory.INVOKE_DECLARED_METHODS, 
-                             MemberCategory.INVOKE_DECLARED_CONSTRUCTORS,
-                             MemberCategory.DECLARED_FIELDS)
-                .registerType(ApiResponse.class, MemberCategory.INVOKE_DECLARED_METHODS,
-                             MemberCategory.INVOKE_DECLARED_CONSTRUCTORS,
-                             MemberCategory.DECLARED_FIELDS)
-                .registerType(FilePathRequest.class, MemberCategory.INVOKE_DECLARED_METHODS,
-                             MemberCategory.INVOKE_DECLARED_CONSTRUCTORS,
-                             MemberCategory.DECLARED_FIELDS);
+                    .registerType(ApiCommand.class, MemberCategory.INVOKE_DECLARED_METHODS,
+                            MemberCategory.INVOKE_DECLARED_CONSTRUCTORS,
+                            MemberCategory.DECLARED_FIELDS)
+                    .registerType(ApiResponse.class, MemberCategory.INVOKE_DECLARED_METHODS,
+                            MemberCategory.INVOKE_DECLARED_CONSTRUCTORS,
+                            MemberCategory.DECLARED_FIELDS)
+                    .registerType(FilePathRequest.class, MemberCategory.INVOKE_DECLARED_METHODS,
+                            MemberCategory.INVOKE_DECLARED_CONSTRUCTORS,
+                            MemberCategory.DECLARED_FIELDS);
 
             hints.resources()
                 .registerPattern("application*.properties")

--- a/CLI/src/main/java/com/AidanC/CLI/NativeImageConfiguration.java
+++ b/CLI/src/main/java/com/AidanC/CLI/NativeImageConfiguration.java
@@ -1,0 +1,32 @@
+package com.AidanC.CLI;
+
+import org.springframework.aot.hint.MemberCategory;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.RuntimeHintsRegistrar;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.ImportRuntimeHints;
+
+@Configuration
+@ImportRuntimeHints(NativeImageConfiguration.CliRuntimeHints.class)
+public class NativeImageConfiguration {
+
+    static class CliRuntimeHints implements RuntimeHintsRegistrar {
+        @Override
+        public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
+            hints.reflection()
+                .registerType(ApiCommand.class, MemberCategory.INVOKE_DECLARED_METHODS, 
+                             MemberCategory.INVOKE_DECLARED_CONSTRUCTORS,
+                             MemberCategory.DECLARED_FIELDS)
+                .registerType(ApiResponse.class, MemberCategory.INVOKE_DECLARED_METHODS,
+                             MemberCategory.INVOKE_DECLARED_CONSTRUCTORS,
+                             MemberCategory.DECLARED_FIELDS)
+                .registerType(FilePathRequest.class, MemberCategory.INVOKE_DECLARED_METHODS,
+                             MemberCategory.INVOKE_DECLARED_CONSTRUCTORS,
+                             MemberCategory.DECLARED_FIELDS);
+
+            hints.resources()
+                .registerPattern("application*.properties")
+                .registerPattern("application*.yml");
+        }
+    }
+}

--- a/CLI/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/CLI/src/main/resources/META-INF/native-image/reflect-config.json
@@ -1,0 +1,30 @@
+[
+  {
+    "name": "org.springframework.shell.standard.ShellComponent",
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "org.springframework.shell.standard.ShellMethod",
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "com.AidanC.CLI.ApiCommand",
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.AidanC.CLI.ApiResponse",
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.AidanC.CLI.FilePathRequest",
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  }
+]


### PR DESCRIPTION
This pull request introduces support for building a native image of the CLI application using GraalVM. The changes include the addition of a build script, updates to the Maven configuration, runtime hints for native image compatibility, and a reflection configuration file.

### Native Image Build Support:

* Added a new script `build-native.sh` to automate the process of building the native CLI application, including steps for cleaning, compiling, processing AOT (Ahead-of-Time), and building the native image. The script also provides success and failure messages. (`CLI/build-native.sh`, [CLI/build-native.shR1-R25](diffhunk://#diff-1729e32173c45434239fca58f29875fc8421d4ef1066b70084907693cd08ee4eR1-R25))

* Updated the Maven `pom.xml` to include the `native-maven-plugin` for building native images, with configurations such as the image name, main class, and build arguments. Also added AOT processing support and excluded Lombok from the native build. (`CLI/pom.xml`, [[1]](diffhunk://#diff-86f0f665cdb25cf18fa4abede715cd29dd91020699ae7d655a3ab4ce29cc8591R33-R34) [[2]](diffhunk://#diff-86f0f665cdb25cf18fa4abede715cd29dd91020699ae7d655a3ab4ce29cc8591R78-R109)

### Runtime Hints for Native Image Compatibility:

* Introduced a new class `NativeImageConfiguration` to register runtime hints for reflection and resource access. This ensures that necessary classes and resources are available during native image compilation. (`CLI/src/main/java/com/AidanC/CLI/NativeImageConfiguration.java`, [CLI/src/main/java/com/AidanC/CLI/NativeImageConfiguration.javaR1-R32](diffhunk://#diff-cb2f4126159a530e3b1d29ce123fc723fdc2abedcb200e866a0421b1db21cac8R1-R32))

### Reflection Configuration:

* Added a `reflect-config.json` file to specify reflection metadata for required classes, enabling their methods, fields, and constructors to be accessible in the native image. (`CLI/src/main/resources/META-INF/native-image/reflect-config.json`, [CLI/src/main/resources/META-INF/native-image/reflect-config.jsonR1-R30](diffhunk://#diff-aeb6c7b3e9d92135387eaadf8857b2209ba908964839a1834eae484207caa5dcR1-R30))